### PR TITLE
Clarify concern with str.format & untrusted input

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -34,7 +34,10 @@ Dangerous functions and modules
 * Python 2 execfile()
 * eval()
 * subprocess.Popen(shell=True)
-* Python 3.6 f-string: `Be Careful with Python's New-Style String Format
+* str.format(), Python 3 str.format_map, and Python 2 unicode.format() all
+  allow arbitrary attribute access on formatted values, and hence access
+  to Python's introspection features:
+  `Be Careful with Python's New-Style String Format
   <http://lucumr.pocoo.org/2016/12/29/careful-with-str-format/>`_
   (Armin Ronacher, December 2016)
 * The ``pickle`` module executes arbitrary Python code: never use it with


### PR DESCRIPTION
The formatting concern raised in Armin Ronacher's article isn't
related to the new f-string feature (as that only works with literals),
but rather to do with calling the `format()` or `format_map()` methods
on a user supplied string, and giving that string access to an object
that exposes one or more Python functions as attributes.